### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "your-sincere-tab-keeper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Chrome extension that limits open tabs with playful maze games",
   "main": "src/background.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Bump version from 1.0.0 to 1.0.1 for the upcoming release.

## Changes
- Update `manifest.json` version to 1.0.1
- Sync version to `package.json` using `npm run sync-version`

## Release Notes
This version includes the fix for the tab limit update modal stuck issue.

🤖 Generated with [Claude Code](https://claude.ai/code)